### PR TITLE
DEVOPS-1128: Update MiraGeoscience/CI-tools dependabot config and pin refs to @v3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,15 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 4
+    ignore:
+      - dependency-name: "MiraGeoscience/CI-tools/.github/actions/*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+      - dependency-name: "MiraGeoscience/CI-tools/.github/workflows/*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
**DEVOPS-1128 - Fix the issue with Dependabot being triggered for minor and patch version for CI-Tools Bumps.**
DEVOPS-1128: two related CI-tools config updates, applied wherever they're relevant to this repo:
- Add an `ignore:` block to dependabot.yml so Dependabot skips minor and patch version updates for `MiraGeoscience/CI-tools/.github/actions/*` and `MiraGeoscience/CI-tools/.github/workflows/*` (major updates still come through).
- Pin any `MiraGeoscience/CI-tools` action/workflow ref that floated on `@main`/`@v2`/`@v1.0.0` to `@v3`.

This PR was run by a PowerShell script with the help of Copilot.