### PR TITLE
GEOPY-2998: Update docs with release notes from GA 4.8 release

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,6 +18,7 @@ The result is exported directly to ``geoh5`` format for visualization in
    usage
    applications
    api/grid_apps
+   release_notes
    THIRD_PARTY_SOFTWARE
 
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -25,23 +25,21 @@ New features
 - Update input variables in github shared workflows
 - Relock on geoapps-utils@release/0.4.0, allow py 3.12
 - Automatically publish python package on Artifactory
-- Add a test to check consistency between conda and pip ve…
+- Add a test to check consistency between conda and pip
 - Update copyright date to 2025
 - Build conda package faster with rattler-build
 - Specify jira component in issue_to_jira
 - Complete package readme and description
-- align license terms in grid-apps
-- environment for coming pre-release
+- Align license terms in grid-apps
+- Environment for coming pre-release
 - Add BlockModel to TensorMesh utility in grid-apps
 - Convert BlockModel to octree
 - Refinement not working on float values
-- Refinement not working on float values
 - Change label on 'objects' for Block Model
-- add workflow for zizmor and apply recommendations
+- Add workflow for zizmor and apply recommendations
 - Use Poetry 2 and have pyproject.toml checked by pre-commit
 - Migrate octree-creation-app to grid-app
-- Migrate octree-creation-app to grid-app
-- auto versioning of python packages
+- Auto versioning of python packages
 - Crash on MT survey as input for mesh creation
 - Possible crash with auto-meshing for potential fields inversion
 - Configure newer zizmor workflows

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -1,0 +1,53 @@
+Release Notes
+=============
+
+Release 0.2.0 (2026-06-04)
+--------------------------
+
+- GEOPY-2573: Line up Drivers with base.Driver class
+- GEOPY-2661: Update minimum requirement to python >=3.12, <3.15 and numpy 2.*
+- GEOPY-2704: fix label capitalization
+- GEOPY-2745: Refresh screenshots of UIJsons in docs
+
+
+Release 0.1.0 (2026-01-06)
+--------------------------
+
+**(First release)**
+
+New features
+^^^^^^^^^^^^
+
+- GEOPY-1589: Transfer block model creation to grid-apps
+- DEVOPS-452: Update package with python-conda-template
+- DEVOPS-440: Fixup README by using regular double quotes
+- GEOPY-1712: Exclude RUF005
+- DEVOPS-466: Update input variables in github shared workflows
+- DEVOPS-515: relock on geoapps-utils@release/0.4.0, allow py 3.12
+- DEVOPS-504: Automatically publish python package on Artifactory
+- DEVOPS-540: Add a test to check consistency between conda and pip ve…
+- GEOPY-1933: Update copyright date to 2025
+- DEVOPS-635: build conda package faster with rattler-build
+- DEVOPS-654: specify jira component in issue_to_jira
+- GEOPY-1861: complete package readme and description
+- GEOPY-2037: align license terms in grid-apps
+- GEOPY-2049: environment for coming pre-release
+- GEOPY-1736: Add BlockModel to TensorMesh utility in grid-apps
+- GEOPY-1508: Convert BlockModel to octree
+- GEOPY-2204: Refinement not working on float values
+- GEOPY-2204: Refinement not working on float values
+- GEOPY-2203: Change label on 'objects' for Block Model
+- DEVOPS-799: add workflow for zizmor and apply recommendations
+- DEVOPS-690: use Poetry 2 and have pyproject.toml checked by pre-commit
+- GEOPY-2157: Migrate octree-creation-app to grid-app
+- GEOPY-2157: Migrate octree-creation-app to grid-app
+- DEVOPS-545: auto versioning of python packages
+- GEOPY-2424: Crash on MT survey as input for mesh creation
+- GEOPY-2509: Possible crash with auto-meshing for potential fields inversion
+- DEVOPS-917: configure newer zizmor workflows
+- DEVOPS-869: no need for jinja nor toml in tests
+- GEOPY-2547: packages get published with 0.0.0 value for __version__
+- GEOPY-2384: merge geoapps 0.12.0 to develop branch
+- DEVOPS-922: build a Python environment for Analyst 4.7 development
+- DEVOPS-922: build a Python environment for Analyst 4.7 development
+- GEOPY-2607: Fix deprecation warning on grid-apps

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,10 +4,10 @@ Release Notes
 Release 0.2.0 (2026-06-04)
 --------------------------
 
-- GEOPY-2573: Line up Drivers with base.Driver class
-- GEOPY-2661: Update minimum requirement to python >=3.12, <3.15 and numpy 2.*
-- GEOPY-2704: fix label capitalization
-- GEOPY-2745: Refresh screenshots of UIJsons in docs
+- Line up Drivers with base.Driver class
+- Update minimum requirement to python >=3.12, <3.15 and numpy 2.*
+- Fix label capitalization
+- Refresh screenshots of UIJsons in docs
 
 
 Release 0.1.0 (2026-01-06)
@@ -18,36 +18,33 @@ Release 0.1.0 (2026-01-06)
 New features
 ^^^^^^^^^^^^
 
-- GEOPY-1589: Transfer block model creation to grid-apps
-- DEVOPS-452: Update package with python-conda-template
-- DEVOPS-440: Fixup README by using regular double quotes
-- GEOPY-1712: Exclude RUF005
-- DEVOPS-466: Update input variables in github shared workflows
-- DEVOPS-515: relock on geoapps-utils@release/0.4.0, allow py 3.12
-- DEVOPS-504: Automatically publish python package on Artifactory
-- DEVOPS-540: Add a test to check consistency between conda and pip ve…
-- GEOPY-1933: Update copyright date to 2025
-- DEVOPS-635: build conda package faster with rattler-build
-- DEVOPS-654: specify jira component in issue_to_jira
-- GEOPY-1861: complete package readme and description
-- GEOPY-2037: align license terms in grid-apps
-- GEOPY-2049: environment for coming pre-release
-- GEOPY-1736: Add BlockModel to TensorMesh utility in grid-apps
-- GEOPY-1508: Convert BlockModel to octree
-- GEOPY-2204: Refinement not working on float values
-- GEOPY-2204: Refinement not working on float values
-- GEOPY-2203: Change label on 'objects' for Block Model
-- DEVOPS-799: add workflow for zizmor and apply recommendations
-- DEVOPS-690: use Poetry 2 and have pyproject.toml checked by pre-commit
-- GEOPY-2157: Migrate octree-creation-app to grid-app
-- GEOPY-2157: Migrate octree-creation-app to grid-app
-- DEVOPS-545: auto versioning of python packages
-- GEOPY-2424: Crash on MT survey as input for mesh creation
-- GEOPY-2509: Possible crash with auto-meshing for potential fields inversion
-- DEVOPS-917: configure newer zizmor workflows
-- DEVOPS-869: no need for jinja nor toml in tests
-- GEOPY-2547: packages get published with 0.0.0 value for __version__
-- GEOPY-2384: merge geoapps 0.12.0 to develop branch
-- DEVOPS-922: build a Python environment for Analyst 4.7 development
-- DEVOPS-922: build a Python environment for Analyst 4.7 development
-- GEOPY-2607: Fix deprecation warning on grid-apps
+- Transfer block model creation to grid-apps
+- Update package with python-conda-template
+- Fixup README by using regular double quotes
+- Exclude RUF005
+- Update input variables in github shared workflows
+- Relock on geoapps-utils@release/0.4.0, allow py 3.12
+- Automatically publish python package on Artifactory
+- Add a test to check consistency between conda and pip ve…
+- Update copyright date to 2025
+- Build conda package faster with rattler-build
+- Specify jira component in issue_to_jira
+- Complete package readme and description
+- align license terms in grid-apps
+- environment for coming pre-release
+- Add BlockModel to TensorMesh utility in grid-apps
+- Convert BlockModel to octree
+- Refinement not working on float values
+- Refinement not working on float values
+- Change label on 'objects' for Block Model
+- add workflow for zizmor and apply recommendations
+- Use Poetry 2 and have pyproject.toml checked by pre-commit
+- Migrate octree-creation-app to grid-app
+- Migrate octree-creation-app to grid-app
+- auto versioning of python packages
+- Crash on MT survey as input for mesh creation
+- Possible crash with auto-meshing for potential fields inversion
+- Configure newer zizmor workflows
+- No need for jinja nor toml in tests
+- Packages get published with 0.0.0 value for __version__
+- Fix deprecation warning on grid-apps


### PR DESCRIPTION
**GEOPY-2998 - Update docs with release notes from GA 4.8 release**
